### PR TITLE
Use string literal types for enhanced type-safety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 src/*.po.ts
+.rollup.cache/
+dist/

--- a/src/hdate.ts
+++ b/src/hdate.ts
@@ -50,6 +50,32 @@ const UNITS_WEEK = 'week';
 const UNITS_MONTH = 'month';
 const UNITS_YEAR = 'year';
 
+type ToFlexibleUnit<U extends TimeUnit> =
+  | U
+  | `${U}s`
+  | Uppercase<U>
+  | Uppercase<`${U}s`>
+  | Capitalize<U>
+  | Capitalize<`${U}s`>
+  | (U extends 'month' ? 'M' : FirstChar<U>);
+
+type FirstChar<S extends string> = S extends `${infer FirstLetter}${string}`
+  ? FirstLetter
+  : never;
+type Capitalize<S extends string> =
+  S extends `${infer FirstLetter}${infer Rest}`
+    ? `${Uppercase<FirstLetter>}${Rest}`
+    : never;
+
+type TimeUnit =
+  | typeof UNITS_DAY
+  | typeof UNITS_WEEK
+  | typeof UNITS_MONTH
+  | typeof UNITS_YEAR;
+
+/** Units that can be passed to `add()` and similar methods. */
+export type FlexibleTimeUnit = ToFlexibleUnit<TimeUnit>;
+
 /**
  * A `HDate` represents a Hebrew calendar date.
  *
@@ -444,7 +470,7 @@ export class HDate {
    * | `month` | `M` | months |
    * | `year` | `y` | years |
    */
-  add(amount: number | string, units = 'd'): HDate {
+  add(amount: number | string, units: FlexibleTimeUnit = 'd'): HDate {
     amount =
       typeof amount === 'string' ? parseInt(amount, 10) : (amount as number);
     if (!amount) {
@@ -492,7 +518,7 @@ export class HDate {
    * const hd2 = hd1.add(1, 'weeks'); // 7 Kislev 5769
    * const hd3 = hd1.add(-3, 'M'); // 30 Av 5768
    */
-  subtract(amount: number, units = 'd'): HDate {
+  subtract(amount: number, units: FlexibleTimeUnit = 'd'): HDate {
     return this.add(amount * -1, units);
   }
 
@@ -723,7 +749,7 @@ export class HDate {
   }
 }
 
-function standardizeUnits(units: string): string {
+function standardizeUnits(units: FlexibleTimeUnit): TimeUnit {
   switch (units) {
     case 'd':
       return UNITS_DAY;

--- a/src/hdate.ts
+++ b/src/hdate.ts
@@ -19,6 +19,7 @@
     along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 import {
+  MonthName,
   SimpleHebrewDate,
   abs2hebrew,
   daysInMonth,
@@ -324,7 +325,7 @@ export class HDate {
    * const hd = new HDate(new Date(2008, 10, 13)); // 15 Cheshvan 5769
    * hd.getMonthName(); // 'Cheshvan'
    */
-  getMonthName(): string {
+  getMonthName(): MonthName {
     return getMonthName(this.getMonth(), this.getFullYear());
   }
 
@@ -610,7 +611,7 @@ export class HDate {
    * import {HDate, months} from '@hebcal/hdate';
    * HDate.getMonthName(months.CHESHVAN, 5769); // 'Cheshvan'
    */
-  static getMonthName(month: number, year: number): string {
+  static getMonthName(month: number, year: number): MonthName {
     return getMonthName(month, year);
   }
 

--- a/src/hdateBase.ts
+++ b/src/hdateBase.ts
@@ -50,7 +50,7 @@ export const months = {
   ADAR_II,
 } as const;
 
-const monthNames0: string[] = [
+const monthNames0 = [
   '',
   'Nisan',
   'Iyyar',
@@ -70,10 +70,13 @@ const monthNames0: string[] = [
  * Regular years are index 0 and leap years are index 1.
  * @private
  */
-const monthNames: string[][] = [
-  monthNames0.concat(['Adar', 'Nisan']),
-  monthNames0.concat(['Adar I', 'Adar II', 'Nisan']),
+const monthNames = [
+  [...monthNames0, 'Adar', 'Nisan'],
+  [...monthNames0, 'Adar I', 'Adar II', 'Nisan'],
 ] as const;
+
+/** Transliterated Hebrew month names. */
+export type MonthName = (typeof monthNames)[number][number];
 
 const edCache: Map<number, number> = new Map<number, number>();
 
@@ -227,7 +230,7 @@ export function daysInMonth(month: number, year: number): number {
  * @param month Hebrew month (e.g. months.TISHREI)
  * @param year Hebrew year
  */
-export function getMonthName(month: number, year: number): string {
+export function getMonthName(month: number, year: number): MonthName {
   assertNumber(month, 'month');
   assertNumber(year, 'year');
   if (month < 1 || month > 14) {

--- a/test/hdate.spec.ts
+++ b/test/hdate.spec.ts
@@ -1,5 +1,5 @@
 import {months} from '../src/hdateBase';
-import {HDate} from '../src/hdate';
+import {FlexibleTimeUnit, HDate} from '../src/hdate';
 import {isoDateString} from '../src/dateFormat';
 
 const NISAN = months.NISAN;
@@ -173,11 +173,11 @@ test('throws-ctor-NaN', () => {
 
   expect(() => {
     new HDate(17, 'Sivan', NaN);
-  }).toThrow( 'HDate called with bad year argument: NaN');
+  }).toThrow('HDate called with bad year argument: NaN');
 
   expect(() => {
     new HDate(17, NaN, 5780);
-  }).toThrow( 'Invalid month number: NaN');
+  }).toThrow('Invalid month number: NaN');
 });
 
 test('getTishreiMonth', () => {
@@ -193,7 +193,6 @@ test('throws-invalid-units', () => {
   expect(() => {
     new HDate(NaN, 'Sivan', 5780);
   }).toThrow('HDate called with bad day argument: NaN');
-
 });
 
 test('toString', () => {
@@ -202,14 +201,22 @@ test('toString', () => {
 });
 
 test('renderGematriya', () => {
-  expect(new HDate(17, 'Tamuz', 5748).renderGematriya()).toBe('י״ז תַּמּוּז תשמ״ח');
-  expect(new HDate(20, 'Tishrei', 5780).renderGematriya()).toBe('כ׳ תִּשְׁרֵי תש״פ');
+  expect(new HDate(17, 'Tamuz', 5748).renderGematriya()).toBe(
+    'י״ז תַּמּוּז תשמ״ח'
+  );
+  expect(new HDate(20, 'Tishrei', 5780).renderGematriya()).toBe(
+    'כ׳ תִּשְׁרֵי תש״פ'
+  );
   expect(new HDate(26, 'Tevet', 8008).renderGematriya()).toBe('כ״ו טֵבֵת ח׳ח׳');
 });
 
 test('renderGematriya-suppressNikud', () => {
-  expect(new HDate(17, 'Tamuz', 5748).renderGematriya(false)).toBe('י״ז תַּמּוּז תשמ״ח');
-  expect(new HDate(17, 'Tamuz', 5748).renderGematriya(true)).toBe('י״ז תמוז תשמ״ח');
+  expect(new HDate(17, 'Tamuz', 5748).renderGematriya(false)).toBe(
+    'י״ז תַּמּוּז תשמ״ח'
+  );
+  expect(new HDate(17, 'Tamuz', 5748).renderGematriya(true)).toBe(
+    'י״ז תמוז תשמ״ח'
+  );
 });
 
 test('render', () => {
@@ -243,7 +250,6 @@ test('render-shvat', () => {
   expect(hd.render('ashkenazi', false)).toBe('15th of Sh’vat');
 });
 
-
 test('render-tevet-ashkenazi', () => {
   const hd = new HDate(3, TEVET, 5769);
   expect(hd.render('en', false)).toBe('3rd of Tevet');
@@ -254,25 +260,39 @@ test('render-tevet-ashkenazi', () => {
 
 test('monthFromName', () => {
   const toTest = [
-    NISAN, 'Nisan_nisan_n_N_Nissan_ניסן',
-    IYYAR, 'Iyyar_Iyar_iyyar_iy_אייר',
-    ELUL, 'Elul_elul_אלול',
-    CHESHVAN, 'Cheshvan_cheshvan_חשון',
-    KISLEV, 'Kislev_kislev_כסלו',
-    SIVAN, 'Sivan_sivan_סייון_סיון',
-    SHVAT, 'Shvat_Sh\'vat_Shevat_שבט',
-    TAMUZ, 'Tamuz_Tammuz_תמוז',
-    TISHREI, 'Tishrei_תשרי',
-    TEVET, 'Tevet_טבת',
-    AV, 'Av_אב',
-    ADAR_I, ['Adar I', 'Adar 1', 'AdarI', 'Adar1', 'אדר א', 'אדר 1'],
-    ADAR_II, ['Adar II', 'Adar 2', 'AdarII', 'Adar2', 'אדר', 'אדר ב', 'אדר 2'],
+    NISAN,
+    'Nisan_nisan_n_N_Nissan_ניסן',
+    IYYAR,
+    'Iyyar_Iyar_iyyar_iy_אייר',
+    ELUL,
+    'Elul_elul_אלול',
+    CHESHVAN,
+    'Cheshvan_cheshvan_חשון',
+    KISLEV,
+    'Kislev_kislev_כסלו',
+    SIVAN,
+    'Sivan_sivan_סייון_סיון',
+    SHVAT,
+    "Shvat_Sh'vat_Shevat_שבט",
+    TAMUZ,
+    'Tamuz_Tammuz_תמוז',
+    TISHREI,
+    'Tishrei_תשרי',
+    TEVET,
+    'Tevet_טבת',
+    AV,
+    'Av_אב',
+    ADAR_I,
+    ['Adar I', 'Adar 1', 'AdarI', 'Adar1', 'אדר א', 'אדר 1'],
+    ADAR_II,
+    ['Adar II', 'Adar 2', 'AdarII', 'Adar2', 'אדר', 'אדר ב', 'אדר 2'],
   ];
 
   for (let i = 0; i < toTest.length; i += 2) {
     const monthNum = toTest[i];
     const samples = toTest[i + 1];
-    const arr = typeof samples == 'string' ? samples.split('_') : samples as string[];
+    const arr =
+      typeof samples == 'string' ? samples.split('_') : (samples as string[]);
     for (const input of arr) {
       expect(HDate.monthFromName(input)).toBe(monthNum);
     }
@@ -340,26 +360,48 @@ test('before', () => {
 });
 
 test('onOrBefore', () => {
-  expect(hd2iso(new HDate(new Date('Wednesday February 19, 2014')).onOrBefore(6))).toBe('2014-02-15');
-  expect(hd2iso(new HDate(new Date('Saturday February 22, 2014')).onOrBefore(6))).toBe('2014-02-22');
-  expect(hd2iso(new HDate(new Date('Sunday February 23, 2014')).onOrBefore(6))).toBe('2014-02-22');
+  expect(
+    hd2iso(new HDate(new Date('Wednesday February 19, 2014')).onOrBefore(6))
+  ).toBe('2014-02-15');
+  expect(
+    hd2iso(new HDate(new Date('Saturday February 22, 2014')).onOrBefore(6))
+  ).toBe('2014-02-22');
+  expect(
+    hd2iso(new HDate(new Date('Sunday February 23, 2014')).onOrBefore(6))
+  ).toBe('2014-02-22');
 });
 
 test('nearest', () => {
-  expect(hd2iso(new HDate(new Date('Wednesday February 19, 2014')).nearest(6))).toBe('2014-02-22');
-  expect(hd2iso(new HDate(new Date('Tuesday February 18, 2014')).nearest(6))).toBe('2014-02-15');
+  expect(
+    hd2iso(new HDate(new Date('Wednesday February 19, 2014')).nearest(6))
+  ).toBe('2014-02-22');
+  expect(
+    hd2iso(new HDate(new Date('Tuesday February 18, 2014')).nearest(6))
+  ).toBe('2014-02-15');
 });
 
 test('onOrAfter', () => {
-  expect(hd2iso(new HDate(new Date('Wednesday February 19, 2014')).onOrAfter(6))).toBe('2014-02-22');
-  expect(hd2iso(new HDate(new Date('Saturday February 22, 2014')).onOrAfter(6))).toBe('2014-02-22');
-  expect(hd2iso(new HDate(new Date('Sunday February 23, 2014')).onOrAfter(6))).toBe('2014-03-01');
+  expect(
+    hd2iso(new HDate(new Date('Wednesday February 19, 2014')).onOrAfter(6))
+  ).toBe('2014-02-22');
+  expect(
+    hd2iso(new HDate(new Date('Saturday February 22, 2014')).onOrAfter(6))
+  ).toBe('2014-02-22');
+  expect(
+    hd2iso(new HDate(new Date('Sunday February 23, 2014')).onOrAfter(6))
+  ).toBe('2014-03-01');
 });
 
 test('after', () => {
-  expect(hd2iso(new HDate(new Date('Wednesday February 19, 2014')).after(6))).toBe('2014-02-22');
-  expect(hd2iso(new HDate(new Date('Saturday February 22, 2014')).after(6))).toBe('2014-03-01');
-  expect(hd2iso(new HDate(new Date('Sunday February 23, 2014')).after(6))).toBe('2014-03-01');
+  expect(
+    hd2iso(new HDate(new Date('Wednesday February 19, 2014')).after(6))
+  ).toBe('2014-02-22');
+  expect(
+    hd2iso(new HDate(new Date('Saturday February 22, 2014')).after(6))
+  ).toBe('2014-03-01');
+  expect(hd2iso(new HDate(new Date('Sunday February 23, 2014')).after(6))).toBe(
+    '2014-03-01'
+  );
 });
 
 test('isHDate', () => {
@@ -506,11 +548,11 @@ test('deltaDays', () => {
 test('throws-invalid-units', () => {
   const hd = new HDate(29, CHESHVAN, 5769);
   expect(() => {
-    hd.add(1, 'x');
-  }).toThrow('Invalid units \'x\'');
+    hd.add(1, 'x' as FlexibleTimeUnit);
+  }).toThrow("Invalid units 'x'");
   expect(() => {
-    hd.subtract(1, 'zs');
-  }).toThrow('Invalid units \'zs\'');
+    hd.subtract(1, 'zs' as FlexibleTimeUnit);
+  }).toThrow("Invalid units 'zs'");
 });
 
 test('fromGematriyaString', () => {


### PR DESCRIPTION
 - This enables autocompletion for the units parameter
 - This allows type-safe `switch()` blocks for month names

I didn't change setMonth(), because that accepts more variants