### PR TITLE
Refactor daysInMonth to use lookup table for static values

### DIFF
--- a/src/hdateBase.ts
+++ b/src/hdateBase.ts
@@ -213,31 +213,23 @@ export function monthsInYear(year: number): number {
   return 12 + +isLeapYear(year); // boolean is cast to 1 or 0
 }
 
+// Static day counts indexed by month number. 0 marks months whose length
+// depends on the year (CHESHVAN, KISLEV, ADAR_I).
+const STATIC_DAYS_IN_MONTH: readonly number[] = [
+  0, 30, 29, 30, 29, 30, 29, 30, 0, 0, 29, 30, 0, 29,
+];
+
 /**
  * Number of days in Hebrew month in a given year (29 or 30)
  * @param month Hebrew month (e.g. months.TISHREI)
  * @param year Hebrew year
  */
 export function daysInMonth(month: number, year: number): number {
-  switch (month) {
-    case IYYAR:
-    case TAMUZ:
-    case ELUL:
-    case TEVET:
-    case ADAR_II:
-      return 29;
-    default:
-      break;
-  }
-  if (
-    (month === ADAR_I && !isLeapYear(year)) ||
-    (month === CHESHVAN && !longCheshvan(year)) ||
-    (month === KISLEV && shortKislev(year))
-  ) {
-    return 29;
-  } else {
-    return 30;
-  }
+  const d = STATIC_DAYS_IN_MONTH[month];
+  if (d !== 0) return d;
+  if (month === ADAR_I) return isLeapYear(year) ? 30 : 29;
+  if (month === CHESHVAN) return longCheshvan(year) ? 30 : 29;
+  return shortKislev(year) ? 29 : 30; // KISLEV
 }
 
 /**


### PR DESCRIPTION
## Summary
Refactored the `daysInMonth` function to improve readability and performance by using a lookup table for months with static day counts, while maintaining the same logic for variable-length months.

## Key Changes
- Introduced `STATIC_DAYS_IN_MONTH` constant array that maps each Hebrew month to its day count (0 indicates variable length)
- Simplified `daysInMonth` logic by first checking the lookup table for static values
- Replaced the switch statement and complex conditional logic with a more concise implementation
- Preserved all existing behavior for variable-length months (CHESHVAN, KISLEV, ADAR_I)

## Implementation Details
- The lookup table uses 0 as a sentinel value to indicate months whose length depends on the year properties
- For static months, the function returns immediately from the lookup table
- For variable months, the function applies the appropriate year-dependent logic (leap year check, long Cheshvan check, short Kislev check)
- This approach reduces code duplication and makes the month length rules more explicit and maintainable

https://claude.ai/code/session_01VTWaREoLypCvHzEkkTWzWm